### PR TITLE
fix(wa): fix score select not updating on song switch (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "serde",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_wa"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nekokan_music_wa/Cargo.toml
+++ b/nekokan_music_wa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_wa"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [lib]

--- a/nekokan_music_wa/src/form.rs
+++ b/nekokan_music_wa/src/form.rs
@@ -121,6 +121,7 @@ pub fn form(props: &FormProps) -> Html {
     let sub_opts = sub_janres_for_main(&props.data.janre.main);
     let title_input_ref = use_node_ref();
     let filename_input_ref = use_node_ref();
+    let score_select_ref = use_node_ref();
     let record_year_text = use_state(|| record_year_join(&props.data.record_year));
 
     let on_save = props.on_save.clone();
@@ -133,6 +134,17 @@ pub fn form(props: &FormProps) -> Html {
         let record_year_text = record_year_text.clone();
         use_effect_with(ry, move |r| {
             record_year_text.set(record_year_join(r));
+            || ()
+        });
+    }
+
+    {
+        let score_select_ref = score_select_ref.clone();
+        let score = props.data.score;
+        use_effect_with(score, move |&score| {
+            if let Some(sel) = score_select_ref.cast::<web_sys::HtmlSelectElement>() {
+                sel.set_value(&score.to_string());
+            }
             || ()
         });
     }
@@ -285,8 +297,8 @@ pub fn form(props: &FormProps) -> Html {
                 <div class="field">
                     <label>{"Score"}</label>
                     <select
+                        ref={score_select_ref.clone()}
                         class={input_class(props, "score")}
-                        value={props.data.score.to_string()}
                         onchange={update_score(props.data.clone(), props.on_data_change.clone())}
                     >
                         { for [1,2,3,4,5,6].iter().map(|&v| {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_server"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## 概要

- Issue #18 のバグを修正しました
- 曲を切り替えたときにスコアの `<select>` が正しく更新されない問題を解消

## 根本原因

Yew 0.21 のバーチャルDOM差分更新において、`<select>` 要素が再生成されずパッチ更新される場合、各 `<option>` の `selected` 属性更新は `defaultSelected`（HTML 属性）を変更するだけで、ブラウザの実際の選択状態（DOM の `selected` プロパティ）には反映されません。そのため曲切り替え後もスコアが前の値（デフォルト値の1）に張り付いて見えることがありました。

## 変更内容

`nekokan_music_wa/src/form.rs` に以下を追加：

- `use_node_ref()` で `score_select_ref` を作成し `<select>` 要素に紐付け
- `use_effect_with(score, ...)` で `props.data.score` 変化のたびにレンダリング後 `HtmlSelectElement::set_value()` を DOM に直接呼び出し、確実に表示を同期
- `<select>` から効果のない `value={...}` 属性を削除

## テスト計画

- [ ] 曲Aを選択 → スコアが正しく表示される
- [ ] 曲Bを選択 → スコアが曲Bの値に正しく切り替わる（特に曲Aと曲Bのスコアが異なる場合）
- [ ] スコアを変更して保存 → 保存後も正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)