### PR TITLE
Fix issue #24: disable removing last track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_server"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "axum",
  "serde",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_wa"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nekokan_music_wa/Cargo.toml
+++ b/nekokan_music_wa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_wa"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [lib]

--- a/nekokan_music_wa/src/form.rs
+++ b/nekokan_music_wa/src/form.rs
@@ -1180,8 +1180,10 @@ fn tracks_section(props: &TracksSectionProps) -> Html {
         let on_data_change = props.on_data_change.clone();
         Callback::from(move |_| {
             let mut d = data.clone();
-            d.tracks.remove(i);
-            on_data_change.emit(d);
+            if d.tracks.len() > 1 {
+                d.tracks.remove(i);
+                on_data_change.emit(d);
+            }
         })
     };
     let tracks_section_err = props.errors.get("tracks").cloned();
@@ -1190,6 +1192,7 @@ fn tracks_section(props: &TracksSectionProps) -> Html {
             <h3>{"Tracks"}</h3>
             { for tracks_section_err.into_iter().map(|e| html! { <span class="error-text">{ e }</span> }) }
             { for props.data.tracks.iter().enumerate().map(|(i, t)| {
+                let can_remove_track = props.data.tracks.len() > 1;
                 let key_title = format!("tracks[{}].title", i);
                 let key_composer = format!("tracks[{}].composer", i);
                 let key_length = format!("tracks[{}].length", i);
@@ -1219,7 +1222,14 @@ fn tracks_section(props: &TracksSectionProps) -> Html {
                                 oninput={update_track_field_str(data.clone(), on_data_change.clone(), i, 4)}/>
                             { for err_length.into_iter().map(|e| html! { <span class="error-text">{ e }</span> }) }
                         </span>
-                        <button type="button" class="btn-remove" onclick={remove(i)}>{"削除"}</button>
+                        <button
+                            type="button"
+                            class="btn-remove"
+                            disabled={!can_remove_track}
+                            onclick={remove(i)}
+                        >
+                            {"削除"}
+                        </button>
                     </div>
                 }
             }) }

--- a/nekokan_music_wa/style.css
+++ b/nekokan_music_wa/style.css
@@ -335,6 +335,16 @@ select.input[multiple] {
   background: rgba(229, 83, 75, 0.35);
 }
 
+.btn-remove:disabled {
+  background: rgba(102, 102, 102, 0.3);
+  color: #9aa3ad;
+  cursor: not-allowed;
+}
+
+.btn-remove:disabled:hover {
+  background: rgba(102, 102, 102, 0.3);
+}
+
 .btn-save {
   margin-top: 0.5rem;
   background: var(--base);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_server"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- Prevent track removal when only one track remains so form data cannot become zero-track.
- Disable the track delete button in that state and show a gray disabled style for clear visual feedback.
- Include package version bump updates already present in Cargo manifests/lockfile.

## Test plan
- [x] Confirm when tracks count is 1, delete button is disabled.
- [x] Confirm when tracks count is 2 or more, delete works as expected.
- [x] Run `cargo test` in `nekokan_music_wa`.
- [x] Rebuild frontend assets with `trunk build`.