### PR TITLE
fix(wa): トラック追加時の Disc/Track No (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_server"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "axum",
  "serde",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_wa"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nekokan_music_wa/Cargo.toml
+++ b/nekokan_music_wa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_wa"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [lib]

--- a/nekokan_music_wa/src/form.rs
+++ b/nekokan_music_wa/src/form.rs
@@ -1165,9 +1165,10 @@ fn tracks_section(props: &TracksSectionProps) -> Html {
         let on_data_change = props.on_data_change.clone();
         Callback::from(move |_| {
             let mut d = data.clone();
+            let (disc_no, no) = disc_and_track_no_for_append(&d.tracks);
             d.tracks.push(Track {
-                disc_no: 1,
-                no: (d.tracks.len() + 1) as i32,
+                disc_no,
+                no,
                 title: String::new(),
                 composer: String::new(),
                 length: String::new(),

--- a/nekokan_music_wa/src/types.rs
+++ b/nekokan_music_wa/src/types.rs
@@ -136,6 +136,15 @@ pub struct Track {
     pub length: String,
 }
 
+/// フォームの「トラック追加」で並べる次の `(disc_no, no)`。直前トラックと同じディスクで、番号は直前+1（issue #23）。
+#[must_use]
+pub fn disc_and_track_no_for_append(tracks: &[Track]) -> (i32, i32) {
+    match tracks.last() {
+        Some(t) => (t.disc_no, t.no.saturating_add(1)),
+        None => (1, 1),
+    }
+}
+
 fn deserialize_composer<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -203,5 +212,41 @@ pub fn sub_janres_for_main(main: &str) -> &'static [&'static str] {
         "Game" => &["Game", "Jazz", "Fusion", "Classical"],
         "Rock" => &["Progressive Rock", "Punk", "Rock"],
         _ => MAIN_JANRES,
+    }
+}
+
+#[cfg(test)]
+mod disc_track_append_tests {
+    use super::{disc_and_track_no_for_append, Track};
+
+    fn t(disc: i32, no: i32) -> Track {
+        Track {
+            disc_no: disc,
+            no,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_defaults_to_disc1_track1() {
+        assert_eq!(disc_and_track_no_for_append(&[]), (1, 1));
+    }
+
+    #[test]
+    fn continues_same_disc_and_increments_track() {
+        let tracks = vec![t(1, 1), t(1, 2)];
+        assert_eq!(disc_and_track_no_for_append(&tracks), (1, 3));
+    }
+
+    #[test]
+    fn follows_last_row_disc_not_always_one() {
+        let tracks = vec![t(1, 1), t(1, 2), t(2, 1), t(2, 2), t(2, 3)];
+        assert_eq!(disc_and_track_no_for_append(&tracks), (2, 4));
+    }
+
+    #[test]
+    fn after_first_track_of_second_disc_next_is_track2_same_disc() {
+        let tracks = vec![t(1, 8), t(2, 1)];
+        assert_eq!(disc_and_track_no_for_append(&tracks), (2, 2));
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_server"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## 概要
GitHub issue #23 に対応しました。

## 変更内容
- トラック追加時の初期値を、常に disc=1 / 通し track ではなく「直前トラックと同じ disc」「直前の track + 1」に変更（\disc_and_track_no_for_append\）。
- \	ypes.rs\ にユニットテストを追加。
- パッケージバージョンを 1.3.2 に更新（\
ekokan_music_wa\ / \
ekokan_music_server\）。

## 確認
- ローカルでテスト成功（依頼者確認済み）

Closes #23

Made with [Cursor](https://cursor.com)