### PR TITLE
fix(wa): scroll to top on song load (#27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_server"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "axum",
  "serde",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "nekokan_music_wa"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nekokan_music_wa/Cargo.toml
+++ b/nekokan_music_wa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_wa"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [lib]
@@ -16,6 +16,6 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 futures = "0.3"
 gloo-timers = { version = "0.3", features = ["futures"] }
-web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlInputElement", "HtmlTextAreaElement", "HtmlSelectElement", "HtmlOptionElement", "HtmlButtonElement", "NodeList", "Url", "console"] }
+web-sys = { version = "0.3", features = ["Window", "Document", "Element", "HtmlInputElement", "HtmlTextAreaElement", "HtmlSelectElement", "HtmlOptionElement", "HtmlButtonElement", "NodeList", "Url", "console", "ScrollToOptions", "ScrollBehavior"] }
 js-sys = "0.3"
 console_error_panic_hook = "0.1"

--- a/nekokan_music_wa/src/app.rs
+++ b/nekokan_music_wa/src/app.rs
@@ -12,6 +12,19 @@ fn log_validation_errors(errs: &FieldErrors) {
     }
 }
 
+/// ページ最上部へスムーススクロール（Issue #27）。
+/// 長い曲リストから下の方の曲を選択した際、ロードされたフォームが画面外にあり
+/// 見えないため、選択時にウィンドウを最上部へ戻す。
+fn scroll_to_top() {
+    if let Some(win) = web_sys::window() {
+        let opts = web_sys::ScrollToOptions::new();
+        opts.set_top(0.0);
+        opts.set_left(0.0);
+        opts.set_behavior(web_sys::ScrollBehavior::Smooth);
+        win.scroll_to_with_scroll_to_options(&opts);
+    }
+}
+
 fn today_str() -> String {
     let d = Date::new_0();
     let y = d.get_full_year();
@@ -92,6 +105,7 @@ pub fn app() -> Html {
             errors.set(FieldErrors::new());
             load_error.set(None);
             save_status.set(None); // 別曲編集開始時に「保存しました。」を消す
+            scroll_to_top(); // Issue #27: フォームが画面外にある場合を考慮して最上部へ
             wasm_bindgen_futures::spawn_local(async move {
                 match api::get_file(&name).await {
                     Ok(mut data) => {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nekokan_music_server"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

- Fix #27: 左サイドバーの曲リストで下の方の曲を選択した際、フォームが画面外にあり見えなかった問題を修正。`on_select_file` でファイル選択直後に `window.scrollTo({ top: 0, behavior: 'smooth' })` 相当を呼び出し、ページ最上部へスムーススクロールする。
- `web_sys::ScrollToOptions` / `ScrollBehavior` を利用。`window()` が `None` の場合に備えて `if let Some` でガード。
- データロードの async 完了を待たずに先にスクロールを開始するため、体感レスポンスが良い。
- `nekokan_music_wa` / `server` のバージョンを `1.3.2` → `1.3.3` に bump。

## Changes

- `nekokan_music_wa/src/app.rs`: `scroll_to_top()` ヘルパー関数を追加し、`on_select_file` から呼び出し
- `nekokan_music_wa/Cargo.toml`: version bump + `web-sys` の features に `ScrollToOptions` / `ScrollBehavior` を追加
- `server/Cargo.toml`: version bump

## Test plan

- [x] `cargo check -p nekokan_music_wa --target wasm32-unknown-unknown` 成功
- [x] `cargo clippy -p nekokan_music_wa --target wasm32-unknown-unknown -- -W clippy::pedantic` で新規コードに警告なし
- [x] `cargo check -p nekokan_music_server` 成功
- [x] `cargo test -p nekokan_music_server` 成功
- [x] `trunk serve` で起動し、下の方の曲をクリックしたときページ最上部へスムーズにスクロールすることを手動確認
- [x] 曲選択時にデータが正しくロードされること（リグレッションなし）を手動確認
- [x] 「Add New Music」リンククリック時の挙動に影響がないことを確認
